### PR TITLE
Make it possible to pass a GitHub token to the action to clone private repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,19 @@ steps:
 
 *if custom options argument string is used, it will overwrite default settings
 
+### Private GitHub Repository
+
+Pass a GitHub access token to action to clone from a private GitHub repository. You can't use the default `GITHUB_TOKEN` as it doesn't have the permission to clone the repository. You have to create an access token manually.
+
+```yaml
+steps:
+- uses: actions/checkout@master
+- name: trufflehog-actions-scan
+  uses: edplato/trufflehog-actions-scan@master
+  with:
+    githubToken: ${{ secrets.GITHUB_CLONE_TOKEN }}
+```
+
 ----
 
 [MIT License](LICENSE)

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,10 @@ author: 'Ed Plato'
 runs:
   using: 'docker'
   image: 'Dockerfile'
+inputs:
+  githubToken:
+    description: 'GitHub Token to access a privat repository'
+    required: false
 branding:
   icon: 'shield'  
   color: 'yellow'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,5 +7,11 @@ if [ -n "$1" ]; then
   args="$@" # Overwrite if new options string is provided
 fi
 
-githubRepo="https://github.com/$GITHUB_REPOSITORY"
+
+if [ -n "${INPUT_GITHUBTOKEN}" ]; then
+  githubRepo="https://$INPUT_GITHUBTOKEN@github.com/$GITHUB_REPOSITORY"
+else
+  githubRepo="https://github.com/$GITHUB_REPOSITORY"
+fi
+
 trufflehog $args $githubRepo


### PR DESCRIPTION
Cool action, but doesn't work for private repositories yet