### PR TITLE
Respect docker proxy settings, if configured

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM python:3.7-alpine
 
+ENV HTTP_PROXY=$HTTP_PROXY
+ENV HTTPS_PROXY=$HTTPS_PROXY
+ENV NO_PROXY=$NO_PROXY
+
 LABEL name="trufflehog-actions-scan"
 LABEL version="1.0.0"
 LABEL repository="https://github.com/edplato/trufflehog-actions-scan"

--- a/README.md
+++ b/README.md
@@ -63,4 +63,7 @@ steps:
 
 ----
 
+### Proxy
+Building the docker container requires access to pypi.python.org/pypi. If you are running docker based actions on a self-hosted runner behind a proxy, you can configure the docker client to [flow proxy info to the container](https://docs.docker.com/network/proxy/#configure-the-docker-client). This action will respect the `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` settings in `~/.docker/config.json`, if set.
+
 [MIT License](LICENSE)

--- a/README.md
+++ b/README.md
@@ -64,6 +64,6 @@ steps:
 ----
 
 ### Proxy
-Building the docker container requires access to pypi.python.org/pypi. If you are running docker based actions on a self-hosted runner behind a proxy, you can configure the docker client to [flow proxy info to the container](https://docs.docker.com/network/proxy/#configure-the-docker-client). This action will respect the `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` settings in `~/.docker/config.json`, if set.
+Building the docker container requires access to pypi.python.org/pypi. If you are running this action ob a self-hosted runner behind a proxy, you can configure the docker client to [flow proxy info to the container](https://docs.docker.com/network/proxy/#configure-the-docker-client). This action will respect the `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` settings in `~/.docker/config.json`, if set.
 
 [MIT License](LICENSE)

--- a/regexes.json
+++ b/regexes.json
@@ -41,5 +41,6 @@
   "Square OAuth Secret": "sq0csp-[0-9A-Za-z\\-_]{43}",
   "Twilio API Key": "SK[0-9a-fA-F]{32}",
   "Twitter Access Token": "[t|T][w|W][i|I][t|T][t|T][e|E][r|R].*[1-9][0-9]+-[0-9a-zA-Z]{40}",
-  "Twitter OAuth": "[t|T][w|W][i|I][t|T][t|T][e|E][r|R].*['|\"][0-9a-zA-Z]{35,44}['|\"]"
-}
+  "Twitter OAuth": "[t|T][w|W][i|I][t|T][t|T][e|E][r|R].*['|\"][0-9a-zA-Z]{35,44}['|\"]",
+  "Github OAuth": " [A-Za-z0-9_]{255}"
+  }


### PR DESCRIPTION
* Updated action to respect HTTP and HTTPS proxy settings, if [configured on the docker client](https://docs.docker.com/network/proxy/#configure-the-docker-client). This allows the action to be run on self-hosted runners behind a proxy without affecting normal users.
* Added Github OAuth token regex