### PR TITLE
Update trufflehog version to 2.2.1 and update README regarding actions/checkout@v2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ LABEL "com.github.actions.description"="Scan repository for secrets with basic t
 LABEL "com.github.actions.icon"="shield"
 LABEL "com.github.actions.color"="yellow"
 
-RUN pip install gitdb2==3.0.0 truffleHog==2.0.99
+RUN pip3 install truffleHog==2.2.1
 RUN apk --update add git less openssh && \
   rm -rf /var/lib/apt/lists/* && \
   rm /var/cache/apk/*

--- a/README.md
+++ b/README.md
@@ -58,8 +58,23 @@ steps:
 
 ```
 
-*if custom options argument string is used, it will overwrite default settings
-*if you want to just run the `trufflehog` command with NO arguments, set as a single spaced string `" "`
+* if custom options argument string is used, it will overwrite default settings
+* if you want to just run the `trufflehog` command with NO arguments, set as a single spaced string `" "`
+
+### If using `actions/checkout@v2`
+
+```yaml
+steps:
+- uses: actions/checkout@v2
+  with:
+    fetch-depth: 0
+- name: trufflehog-actions-scan
+  uses: edplato/trufflehog-actions-scan@master
+  with:
+    scanArguments: "--regex --entropy=False --max_depth=5 --rules /regexes.json" # Add custom options here*
+
+```
+With `actions/checkout@v2` make sure to include `fetch-depth: 0` when checking out the repository as it will make the entire git commit history available to be scanned. Alternatively, ensure the value for `fetch-depth` is greater than the `max_depth` flag used by trufflehog to ensure that trufflehog runs at your desired commit history depth.
 
 ----
 


### PR DESCRIPTION
Suggesting upgrade to add support for the `allow` flag in Trufflehog. 

README update relating to #16 